### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -20,7 +20,7 @@ impl ErasedValue {
             ptr: Box::into_raw(Box::new(value)).cast(),
             drop: {
                 unsafe fn drop<T>(ptr: *mut ()) {
-                    let _ = Box::from_raw(ptr.cast::<T>());
+                    let _ = unsafe { Box::from_raw(ptr.cast::<T>()) };
                 }
                 drop::<T>
             },
@@ -41,7 +41,7 @@ impl ErasedValue {
             any::type_name::<T>(),
         );
 
-        let b = Box::from_raw(self.ptr.cast::<T>());
+        let b = unsafe { Box::from_raw(self.ptr.cast::<T>()) };
         mem::forget(self);
         *b
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/serde-untagged/0.1.2")]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::doc_markdown,
     clippy::enum_glob_use,


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.